### PR TITLE
Added support for (PKS) and an initContainer  to register the SDC on starting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+myvals.yaml

--- a/vxflex-csi/templates/agent.yaml
+++ b/vxflex-csi/templates/agent.yaml
@@ -48,7 +48,19 @@ spec:
     spec:
       serviceAccount: {{ .Release.Name }}-agent
       hostNetwork: true
-      containers:
+      initContainers:
+        - name: register-sdc
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: ubuntu
+          command: ["/bin/bash","-c","/usr/bin/apt-get update && /usr/bin/apt install -y libnuma1 libaio1 && /opt/emc/scaleio/sdc/bin/drv_cfg --add_mdm --ip {{ required "MDM IP required" .Values.mdmIP }}"]
+          volumeMounts:
+            - name: scaleio-path-bin
+              mountPath: /opt/emc/scaleio/sdc/bin
+      containers:  
         - name: agent
           securityContext:
             privileged: true
@@ -73,8 +85,8 @@ spec:
               mountPropagation: "Bidirectional"
             - name: dev
               mountPath: /dev
-            - name: scaleio-path-opt
-              mountPath: /opt/emc
+            - name: scaleio-path-bin
+              mountPath: /opt/emc/scaleio/sdc/bin
             - name: scaleio-path-bin
               mountPath: /bin/emc
         - name: driver-registrar
@@ -111,5 +123,5 @@ spec:
             type: Directory
         - name: scaleio-path-bin
           hostPath:
-            path: /bin/emc
+            path: {{ required "Location of drv_cfg binary" .Values.scaleio-path-bin }}
             type: Directory

--- a/vxflex-csi/values.yaml
+++ b/vxflex-csi/values.yaml
@@ -16,6 +16,9 @@
 # provision volumes.
 # storagePool: sp
 
+#"mdmIP" defines the MDM(s) the SDC's should register with on start, comma separated
+mdmIP: 192.168.1.1
+
 # "volumeNamePrefix" defines a string prepended to each volume created by the
 # CSI driver.
 volumeNamePrefix: vxvol
@@ -23,6 +26,9 @@ volumeNamePrefix: vxvol
 # "controllerCount" defines the number of VxFlex controller nodes to deploy to
 # the Kubernetes release
 controllerCount: 1
+
+#Where is the drv_cfg binary on the host?  By default, /bin/emc, but might be /var/vcap/packages/scaleIO_kernel on PKS
+scaleio-path-bin: /bin/emc
 
 images:
   # "images.agent" defines the container images used for the agent container.


### PR DESCRIPTION


* Added .gitginore to prevent checking in myvals.yaml files
* Updated agent.yaml template:
    * Added init container that uses `mdmIP` value defined in values.yaml to perform initial registration before starting the agent
    * Added configurable mdmIP value
* Added path for drv_cfg file, as its different on PKS